### PR TITLE
explicitly cast uv_after_work_cb to uv_queue_work

### DIFF
--- a/src/fb-bindings-blob.cc
+++ b/src/fb-bindings-blob.cc
@@ -206,7 +206,7 @@ Handle<Value> FBblob::Read(const Arguments& args)
 
 	uv_work_t* req = new uv_work_t();
     req->data = r_req;
-    uv_queue_work(uv_default_loop(), req, EIO_Read,  EIO_After_Read);
+    uv_queue_work(uv_default_loop(), req, EIO_Read,  (uv_after_work_cb)EIO_After_Read);
 
     
     //uv_ref(uv_default_loop());
@@ -363,7 +363,7 @@ Handle<Value>
 
 	uv_work_t* req = new uv_work_t();
     req->data = w_req;
-    uv_queue_work(uv_default_loop(), req, EIO_Write,  EIO_After_Write);
+    uv_queue_work(uv_default_loop(), req, EIO_Write,  (uv_after_work_cb)EIO_After_Write);
 
     
     //uv_ref(uv_default_loop());

--- a/src/fb-bindings-connection.cc
+++ b/src/fb-bindings-connection.cc
@@ -504,7 +504,7 @@ Handle<Value>
     
 	uv_work_t* req = new uv_work_t();
     req->data = conn_req;
-    uv_queue_work(uv_default_loop(), req, EIO_Connect,  EIO_After_Connect);
+    uv_queue_work(uv_default_loop(), req, EIO_Connect,  (uv_after_work_cb)EIO_After_Connect);
 
     
    // uv_ref(uv_default_loop());
@@ -676,7 +676,7 @@ Handle<Value>
 
     uv_work_t* req = new uv_work_t();
     req->data = tr_req;
-    uv_queue_work(uv_default_loop(), req, EIO_TransactionRequest,  EIO_After_TransactionRequest);
+    uv_queue_work(uv_default_loop(), req, EIO_TransactionRequest,  (uv_after_work_cb)EIO_After_TransactionRequest);
 
     
     //uv_ref(uv_default_loop());
@@ -713,7 +713,7 @@ Handle<Value>
 
 	uv_work_t* req = new uv_work_t();
     req->data = tr_req;
-    uv_queue_work(uv_default_loop(), req, EIO_TransactionRequest,  EIO_After_TransactionRequest);
+    uv_queue_work(uv_default_loop(), req, EIO_TransactionRequest,  (uv_after_work_cb)EIO_After_TransactionRequest);
     
    // uv_ref(uv_default_loop());
     conn->Ref();
@@ -749,7 +749,7 @@ Handle<Value>
 
     uv_work_t* req = new uv_work_t();
     req->data = tr_req;
-    uv_queue_work(uv_default_loop(), req, EIO_TransactionRequest,  EIO_After_TransactionRequest);
+    uv_queue_work(uv_default_loop(), req, EIO_TransactionRequest,  (uv_after_work_cb)EIO_After_TransactionRequest);
     
    // uv_ref(uv_default_loop());
     conn->Ref();
@@ -889,7 +889,7 @@ Handle<Value>
 
 	uv_work_t* req = new uv_work_t();
     req->data = q_req;
-    uv_queue_work(uv_default_loop(), req, EIO_Query,  EIO_After_Query);
+    uv_queue_work(uv_default_loop(), req, EIO_Query,  (uv_after_work_cb)EIO_After_Query);
     
     
    //uv_ref(uv_default_loop());

--- a/src/fb-bindings-fbresult.cc
+++ b/src/fb-bindings-fbresult.cc
@@ -721,7 +721,7 @@ void FBResult::EIO_After_Fetch(uv_work_t *req)
 		    
 			uv_work_t* req = new uv_work_t();
             req->data = f_req;
-            uv_queue_work(uv_default_loop(), req, EIO_Fetch,  EIO_After_Fetch);	
+            uv_queue_work(uv_default_loop(), req, EIO_Fetch,  (uv_after_work_cb)EIO_After_Fetch);	
 
 
         	//uv_ref(uv_default_loop());
@@ -842,7 +842,7 @@ Handle<Value>
 
 	uv_work_t* req = new uv_work_t();
     req->data = f_req;
-    uv_queue_work(uv_default_loop(), req, EIO_Fetch,  EIO_After_Fetch);	
+    uv_queue_work(uv_default_loop(), req, EIO_Fetch,  (uv_after_work_cb)EIO_After_Fetch);	
     
     //uv_ref(uv_default_loop());
     res->Ref();

--- a/src/fb-bindings-statement.cc
+++ b/src/fb-bindings-statement.cc
@@ -255,7 +255,7 @@ Handle<Value>
 
 	uv_work_t* req = new uv_work_t();
     req->data = e_req;
-    uv_queue_work(uv_default_loop(), req, EIO_Exec,  EIO_After_Exec);
+    uv_queue_work(uv_default_loop(), req, EIO_Exec,  (uv_after_work_cb)EIO_After_Exec);
 
     
    // uv_ref(uv_default_loop());


### PR DESCRIPTION
Per the node 0.8 -> 0.10 migration guide:
The uv_after_work_cb signature has changed to take a second integer
argument indicating status. For backwards compatibility, explicitly cast
the 4th argument to uv_queue_work.

Fixes #17
