### PR TITLE
fix fatal error: uv-private/ev.h: No such file or directory

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -8,7 +8,7 @@
                    './src/fb-bindings-fbeventemitter.cc', 
                    './src/fb-bindings-statement.cc' ],
       'include_dirs': [
-          '/usr/include/'
+          '/usr/include/','/usr/include/node','/usr/local/include/node'
       ],
       'libraries': [ '-L/usr/lib -lfbclient' ]
     }


### PR DESCRIPTION
fix fatal error: uv-private/ev.h: No such file or directory

I have added include headers from node installed from source 

maybe it needs refactoring 
