### PR TITLE
npm warning 'repositories' (plural) Not supported.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ]
 , "bugs" : { "url" : "http://github.com/xdenser/node-firebird-libfbclient/issues" } 
 , "licenses" : [ { "type" : "MIT" } ] 
-, "repositories" :
+, "repository" :
   [ { "type" : "git"
     , "url" : "http://github.com/xdenser/node-firebird-libfbclient.git"
     }


### PR DESCRIPTION
sudo npm install firebird
npm WARN package.json firebird@0.0.10 'repositories' (plural) Not supported.
npm WARN package.json Please pick one as the 'repository' field
