### PR TITLE
'repositories' (plural) Not supported. Please pick one as the 'repository' field

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,12 +23,6 @@
     , "url" : "http://github.com/xdenser/node-firebird-libfbclient.git"
     }
   ],
-  "repositories": [
-    {
-      "type": "git",
-      "url": "http://github.com/xdenser/node-firebird-libfbclient.git"
-    }
-  ],
   "dependencies": {
     "nan": "^1.6.0"
   }


### PR DESCRIPTION
...y' field

fixes warning npm WARN package.json firebird@v0.0.12 'repositories' (plural) Not supported. Please pick one as the 'repository' field