### PR TITLE
Multieventcont

### DIFF
--- a/src/fb-bindings-eventblock.cc
+++ b/src/fb-bindings-eventblock.cc
@@ -312,8 +312,8 @@ void event_block::removeEvent(char *Event)
       size_t new_length = blength - sz;
       size_t tale_length = blength - (buf - (char*)event_buffer) - sz;    
       if(tale_length){
-        memcpy(buf, buf+sz, tale_length);
-        memcpy(rb, rb+sz, tale_length);
+        memmove(buf, buf+sz, tale_length);
+        memmove(rb, rb+sz, tale_length);
       }    
       if(new_length==1) new_length = 0;
       

--- a/tests/def/test-events.js
+++ b/tests/def/test-events.js
@@ -270,15 +270,17 @@ exports.AddAndDeleteMultiComplex = function(test){
     called = true;
   });
   var eN = 'eventName';
-  conn.addFBevent(eN + 1);
-  conn.addFBevent(eN + 2);
-  conn.addFBevent(eN + 3);
-  conn.addFBevent(eN + 10);
-  conn.deleteFBevent(eN + 3);
-  conn.deleteFBevent(eN + 2);
-  conn.deleteFBevent(eN + 10);
-  conn.deleteFBevent(eN + 1);
-  GenEvent(eN + 1);
+  conn.addFBevent(eN);
+  var evs = [...Array(20).keys()];
+  for (i in evs) {
+    conn.addFBevent(eN+i);
+  }
+  for (i in evs) {
+    conn.deleteFBevent(eN+i);
+  }
+
+  conn.deleteFBevent(eN);
+  GenEvent(eN);
 
   setTimeout(function(){
        test.ok(!called,"Event not called");


### PR DESCRIPTION
This appears to completely fix #70 .

It was using memcpy to strip out the events in the middle of event_buffer and result_buffer, but since it was moving overlapping src and dests this caused... undefined behavior leading to crashes. swapped out to memmove as per memcpy(3) man page and now the more complex add and remove test passes.