### PR TITLE
max password length is 20 in firebird 3.0

### DIFF
--- a/src/fb-bindings-connection.h
+++ b/src/fb-bindings-connection.h
@@ -9,7 +9,7 @@
 
 #define MAX_USERNAME_LENGTH 31
 #define MAX_ROLENAME_LENGTH 31
-#define MAX_PASSWORD_LENGTH 8 
+#define MAX_PASSWORD_LENGTH 20 
 
 #include <uv.h>
 #include "./fb-bindings.h"


### PR DESCRIPTION
max password length is 20 in firebird 3.0 and accepted but ignored that part if greater than 8 in fb 2x 

https://www.firebirdsql.org/file/documentation/release_notes/html/en/3_0/rnfb30-security-new-authentication.html