### PR TITLE
Add charset options lc_type and lc_decode to createConnection

### DIFF
--- a/firebird.js
+++ b/firebird.js
@@ -135,8 +135,8 @@ binding.FBblob.prototype._readAll = function(initialSize, chunkSize, callback){
 }
 
 
-exports.createConnection = function () {
-  var c = new Connection();
+exports.createConnection = function (options) {
+  var c = new Connection(options);
   return c;
 };
 

--- a/src/fb-bindings-connection.cc
+++ b/src/fb-bindings-connection.cc
@@ -47,7 +47,7 @@ void
     Nan::Set(target, Nan::New("Connection").ToLocalChecked(), Nan::GetFunction(t).ToLocalChecked());
   }
   
-bool Connection::Connect (const char* Database,const char* User,const char* Password,const char* Role)
+bool Connection::Connect (const char* Database,const char* User,const char* Password,const char* Role, const char* lc_type)
   {
     if (db) return false;
     short i = 0, len;
@@ -83,22 +83,12 @@ bool Connection::Connect (const char* Database,const char* User,const char* Pass
     strncpy(&(dpb[i]), Role, len);
     i += len;
 	
-	if (Nan::HasPrivate(handle(), Nan::New("lc_type").ToLocalChecked()).FromMaybe(false)) {
-		Nan::Utf8String _lc_type(Nan::GetPrivate(handle(), Nan::New("lc_type").ToLocalChecked()).ToLocalChecked()->ToString(Nan::GetCurrentContext()).ToLocalChecked());
-		
-		dpb[i++] = isc_dpb_lc_ctype;
-		len = (short) strlen (*_lc_type);
-		dpb[i++] = (char) len;
-		strncpy(&(dpb[i]), *_lc_type, len);
-		i += len;
-		isUTF8lctype = !strncmp(*_lc_type, "UTF8", len) || !strncmp(*_lc_type, "utf8", len);
-	} else {
-		dpb[i++] = isc_dpb_lc_ctype;
-		len = (short) strlen (lc_type);
-		dpb[i++] = (char) len;
-		strncpy(&(dpb[i]), lc_type, len);
-		i += len;	
-	}
+	dpb[i++] = isc_dpb_lc_ctype;
+	len = (short) strlen (lc_type);
+	dpb[i++] = (char) len;
+	strncpy(&(dpb[i]), lc_type, len);
+	i += len;
+	isUTF8lctype = !strncmp(lc_type, "UTF8", len) || !strncmp(lc_type, "utf8", len);
     
     connected = false;
     if(isc_attach_database(status, 0, Database, &(db), i, dpb)) return false;
@@ -417,9 +407,13 @@ NAN_METHOD(Connection::ConnectSync)
     Nan::Utf8String User(info[1]->ToString(Nan::GetCurrentContext()).ToLocalChecked());
     Nan::Utf8String Password(info[2]->ToString(Nan::GetCurrentContext()).ToLocalChecked());
     Nan::Utf8String Role(info[3]->ToString(Nan::GetCurrentContext()).ToLocalChecked());
-    
+	Local<String> _lc_type = Nan::New<String>(connection->lc_type).ToLocalChecked();
+	
+	if (Nan::HasPrivate(info.This(), Nan::New("lc_type").ToLocalChecked()).FromMaybe(false)) {
+		_lc_type = Nan::GetPrivate(info.This(), Nan::New("lc_type").ToLocalChecked()).ToLocalChecked()->ToString(Nan::GetCurrentContext()).ToLocalChecked();
+	}
 
-    bool r = connection->Connect(*Database,*User,*Password,*Role);
+    bool r = connection->Connect(*Database,*User,*Password,*Role,*Nan::Utf8String(_lc_type));
 
     if (!r) {
       return Nan::ThrowError(
@@ -466,11 +460,13 @@ void Connection::EIO_Connect(uv_work_t *req)
                      **(conn_req->Database),
                      **(conn_req->User), 
                      **(conn_req->Password),
-                     **(conn_req->Role));
+                     **(conn_req->Role),
+					 **(conn_req->lc_type));
     delete conn_req->Database;
     delete conn_req->User;
     delete conn_req->Password;
     delete conn_req->Role;
+	delete conn_req->lc_type;
     
     return ;
    
@@ -502,6 +498,13 @@ NAN_METHOD(Connection::Connect)
     conn_req->User     = new Nan::Utf8String(info[1]->ToString(Nan::GetCurrentContext()).ToLocalChecked());
     conn_req->Password = new Nan::Utf8String(info[2]->ToString(Nan::GetCurrentContext()).ToLocalChecked());
     conn_req->Role     = new Nan::Utf8String(info[3]->ToString(Nan::GetCurrentContext()).ToLocalChecked());
+	
+	if (Nan::HasPrivate(info.This(), Nan::New("lc_type").ToLocalChecked()).FromMaybe(false)) {
+		
+		conn_req->lc_type = new Nan::Utf8String(Nan::GetPrivate(info.This(), Nan::New("lc_type").ToLocalChecked()).ToLocalChecked()->ToString(Nan::GetCurrentContext()).ToLocalChecked());
+	} else {
+		conn_req->lc_type = new Nan::Utf8String(Nan::New(conn->lc_type).ToLocalChecked());
+	}
     
     conn->start_async();
     

--- a/src/fb-bindings-connection.h
+++ b/src/fb-bindings-connection.h
@@ -34,7 +34,7 @@ class Connection : public FBEventEmitter {
   static void
   Initialize (v8::Local<v8::Object> target);
  
-  bool Connect (const char* Database,const char* User,const char* Password,const char* Role);
+  bool Connect (const char* Database,const char* User,const char* Password,const char* Role, const char* lc_type);
  
   bool Close();
   
@@ -67,6 +67,7 @@ class Connection : public FBEventEmitter {
      Nan::Utf8String *User;
      Nan::Utf8String *Password;
      Nan::Utf8String *Role;
+	 Nan::Utf8String *lc_type;
      bool res;
   };
   


### PR DESCRIPTION
Hi.

I made changes to support options on createConnection to change lc_type and a lc_decode function to decode the result buffer to string. Example:

`let connection = Firebird.createConnection({ lc_type: 'WIN1252', lc_decode: (data) => iconv.decode(data, 'windows-1252') });`

I run tests here and the code is working fine (node 12), this will probably resolve the issues #9 and #87 