### PR TITLE
fix: return `this` for `destroy` and `end`

### DIFF
--- a/firebird.js
+++ b/firebird.js
@@ -201,6 +201,7 @@ Stream.prototype.resume = function(){
 Stream.prototype.destroy = function () {
   this._destroyed = true;
   this.check_destroyed();
+  return this;
 };
 
 Stream.prototype.check_destroyed = function () {
@@ -234,6 +235,6 @@ Stream.prototype.end = function(data, encoding, fd) {
         })
     }
     else this.destroy();
-   
+    return this;
 }
 


### PR DESCRIPTION
For consistency with Node readable stream implementation, `destroy()` and `end()` should likely return `this` - https://nodejs.org/api/stream.html#readabledestroyerror

**Context**: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/57473